### PR TITLE
Trim debian base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,7 @@ RUN bash -ex create_pam_debians.sh
 FROM debian:stretch-slim
 COPY --from=0 /tmp/*.deb /
 COPY setup.sh /usr/local/bin/
-RUN bash -ex setup.sh
+RUN bash -ex setup.sh && rm /usr/local/bin/setup.sh
+
+FROM scratch
+COPY --from=1 / /

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,10 @@
 #!/bin/bash -ex
 # Seperated specifically to enable easy modificaiton of Dockerfile to cache this really long step
 
-# Install pam requirements
-apt-get update
-apt-get install -y libc6-dev libc-dev
-
 # From file from earlier docker file
 # https://github.com/pi-hole/docker-pi-hole/issues/243
-dpkg -i libpam-doc*.deb libpam-modules*.deb libpam-runtime*.deb libpam0g*.deb
+dpkg -i libpam-modules_*.deb \
+        libpam-modules-bin_*.deb \
+        libpam-runtime_*.deb \
+        libpam0g_*.deb
 rm /*.deb
-rm -rf /var/cache/apt/archives /var/lib/apt/lists/*

--- a/setup.sh
+++ b/setup.sh
@@ -7,4 +7,12 @@ dpkg -i libpam-modules_*.deb \
         libpam-modules-bin_*.deb \
         libpam-runtime_*.deb \
         libpam0g_*.deb
+
+# Hold patched packages so users don't accidently unpatch the image with
+# apt-get upgrade
+apt-mark hold libpam-modules
+apt-mark hold libpam-modules-bin
+apt-mark hold libpam-runtime
+apt-mark hold libpam0g
+
 rm /*.deb


### PR DESCRIPTION
## Description

This PR aims to bring the base image size down to be on par with debian:stretch-slim by only patching the default packages included in debian:stretch-slim. 

During testing, it was also noted that the image can be easily unpatched via apt-get upgrade or installing a package that depends on the patched packages. This is addressed by applying package
holds.
## Motivation and Context

From: pi-hole/docker-pi-hole/pull/358
> Increased the docker image size, but haven't had time to hunt down where that size is. Still running the clean up of /var/lib/apt and also added a deletion of the manually re-built debs for pam.

## How Has This Been Tested?

pihole:v4.3_amd64 was rebuilt using the modified image as it's base. It was confirmed that:
- pihole dependencies did not reintroduce (and thus depend on) the removed packages
- it passed all tests run by tox

## Types of changes

- Cut out unused packages to decrease docker image size (libpam-doc, libpam0g-dev, libpam* debug symbol packages).
- Added a third build-stage to properly apply the "deletion of the manually re-built debs for pam"
- Added package holds to make it harder for users to accidentally unpatch the image.