### PR TITLE
Pin Patched Packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,17 @@ COPY create_pam_debians.sh /usr/local/bin/
 RUN bash -ex create_pam_debians.sh
 
 FROM debian:stretch-slim
+WORKDIR /usr/local/repos/pam
+COPY --from=0 /tmp/*.deb ./
+COPY create_local_pam_repo.sh /usr/local/bin
+RUN bash -ex create_local_pam_repo.sh
+
+FROM debian:stretch-slim
 COPY --from=0 /tmp/*.deb /
+COPY --from=1 /etc/apt/ /etc/apt/
+COPY --from=1 /usr/local/repos/pam /usr/local/repos/pam
 COPY setup.sh /usr/local/bin/
 RUN bash -ex setup.sh && rm /usr/local/bin/setup.sh
 
 FROM scratch
-COPY --from=1 / /
+COPY --from=2 / /

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,7 @@ RUN bash -ex create_pam_debians.sh
 FROM debian:stretch-slim
 COPY --from=0 /tmp/*.deb /
 COPY setup.sh /usr/local/bin/
-RUN bash -ex setup.sh
+RUN bash -ex setup.sh && rm /usr/local/bin/setup.sh
+
+FROM scratch
+COPY --from=1 / /

--- a/create_local_pam_repo.sh
+++ b/create_local_pam_repo.sh
@@ -1,0 +1,23 @@
+# Install dpkg-dev for dpkg-scanpackages
+apt-get update
+apt-get install --no-install-recommends -y dpkg-dev
+rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
+
+# Purge debug symbol packages.
+rm *dbgsym*.deb
+
+# Create a Packages.gz file for apt/dselect
+dpkg-scanpackages . | gzip -9c > Packages.gz
+
+#-------------------------------------------------------------------------------
+# APT-PINNING
+
+# Pin local repo as preferred source by listing it first
+sed -i "1ideb [trusted=yes] file:${PWD} /" /etc/apt/sources.list
+
+# Pin package version to that in local repo
+cat >> /etc/apt/preferences << EOF
+Package: *  
+Pin: origin ""  
+Pin-Priority: 999
+EOF

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,10 @@
 #!/bin/bash -ex
 # Seperated specifically to enable easy modificaiton of Dockerfile to cache this really long step
 
-# Install pam requirements
-apt-get update
-apt-get install -y libc6-dev libc-dev
-
 # From file from earlier docker file
 # https://github.com/pi-hole/docker-pi-hole/issues/243
-dpkg -i libpam-doc*.deb libpam-modules*.deb libpam-runtime*.deb libpam0g*.deb
+dpkg -i libpam-modules_*.deb \
+        libpam-modules-bin_*.deb \
+        libpam-runtime_*.deb \
+        libpam0g_*.deb
 rm /*.deb
-rm -rf /var/cache/apt/archives /var/lib/apt/lists/*

--- a/setup.sh
+++ b/setup.sh
@@ -7,4 +7,12 @@ dpkg -i libpam-modules_*.deb \
         libpam-modules-bin_*.deb \
         libpam-runtime_*.deb \
         libpam0g_*.deb
+
+# Hold patched packages so users don't accidently unpatch the image with
+# apt-get upgrade
+apt-mark hold libpam-modules
+apt-mark hold libpam-modules-bin
+apt-mark hold libpam-runtime
+apt-mark hold libpam0g
+
 rm /*.deb


### PR DESCRIPTION
## Description

Optional improvement over package holds that prevents the image from being unpatched without the user knowingly doing so.

A local repo is used to server the patched packages made by `create_pam_debians.sh` and apt pinning
is used to force apt-get to always prefer the local repo for said packages. Packages removed by PR #1 are made available for install on an as needed basis.
## Motivation and Context

Make the patched base image less fragile to user error
## How Has This Been Tested?

pihole:v4.3_amd64 was rebuilt using the modified image as it's base. It was confirmed that:
- Passes all tests
- local repo serves the patched packages and that they are preferred via Cl inspection (e.g. apt-get update && apt-get upgrade -s -y && apt-get install -s -y libpam0g-dev defer to the local repo)
## Types of changes

- Increase docker size (55.3MB -> 56.6MB on disk)
- Added local repo to server patched packages, facilitated by an extra build stage and create_local_pam_repo.sh helper